### PR TITLE
Add HTML talk schedule with times, titles, and speaker info

### DIFF
--- a/index.html
+++ b/index.html
@@ -32,15 +32,15 @@
 		<div class="row clearfix">
 			<h1 class="titles">About Us</h1>
 			<a href="https://www.twitch.tv/thelivecoders"><img src="imgs/Lcconf.png" id="conf_img" alt="Image with conference info"></a>
-			<h2> SAVE THE DATE! </h2> 
+			<h2> SAVE THE DATE! </h2>
 			<h2> April 9, 2020. An online only conference put on by The Live Coders team on <a href="https://www.twitch.tv/TheLiveCoders">Twitch!</a></h2>
-			<p> You may be wondering who we are! We are The Live Coders, an outgoing and enthusiastic group of friendly channels that write code, teach about technology, and promote the technical community.</p> 
+			<p> You may be wondering who we are! We are The Live Coders, an outgoing and enthusiastic group of friendly channels that write code, teach about technology, and promote the technical community.</p>
 			<p> With conferences everywhere being cancelled or postponed, we didn't want to let prepared talks to go waste and decided to put on a free (all-day) online conference for everyone on <a href="https://www.twitch.tv/TheLiveCoders">Twitch</a>, with talks covering various topics. </p>
 			<p>To stay up to date with announcements about the conference, please follow us on <a href="https://twitter.com/thelivecoders">Twitter!</a></p>
 			<p> Learn who our speakers are and what the schedule looks like below: </p>
 		</div>
 	</section>
-	
+
 
 	<section>
 		<div class="sectionSeparator"></div>
@@ -51,7 +51,7 @@
 		<div class="row">
 			<h1 class="titles">Speakers</h1>
 			<h3> We have many amazing speakers covering various topics, go check them out! </h3>
-			
+
 			<div class="ui cards">
 			  <div class="card">
 			    <div class="content">
@@ -257,8 +257,7 @@
 			      </div>
 			    </div>
 			    <div class="extra content">
-			      	<a href="https://www.twitch.tv/noopkat" class="speakerIcons"><i class="twitch icon"></i></a>
-					<a href="https://twitter.com/noopkat" class="speakerIcons"><i class="twitter square icon"></i></a>
+
 			    </div>
 			  </div>
 
@@ -333,11 +332,11 @@
 		<div class="row">
 			<h2>Team Sponsors</h2>
 			<a href="https://fauna.com/"><img class="teamsponsor" src="sponsors/fauna.png"></a>
-		
+
 			<h2>Conference Sponsors</h2>
 			<a href="https://www.couchbase.com/"><img class="sponsorimg2" src="sponsors/cblogo.png"></a>
 			<a href="https://circle.ci/2JwtCCq"><img class="sponsorimg2" src="sponsors/circleci.png"></a>
-			
+
 		</div>
 	</section>
 
@@ -350,12 +349,147 @@
 		<div class="row">
 			<h1 class="titles">Schedule</h1>
 			<h3> Schedule is tentative and subject to change (will update any changes!) </h3>
-
-			<p>Due to the amount of speakers we have, we are breaking up the conference into two parts, Part A and Part B. The listed times are in PDT. Each talk will last about 45 minutes. </p>
-			<p>Download the schedule pdf <a href="schedulepdf.pdf">here</a></p>
-
-			<img class="schedule" src="schedule/schedule.png">
-
+			<div class="schedule-list">
+				<p>Due to the amount of speakers we have, we are breaking up the conference into two parts, Part A and Part B. The listed times are in PDT. Each talk will last about 45 minutes. </p>
+				<p>Download the schedule pdf <a href="schedulepdf.pdf">here</a></p>
+			<h1>Conference Part A</h1>
+			  <h2>
+				Thursday, April 9th 2020
+			  </h2>
+			  <ol>
+				<li>
+				  <div class="time">
+					<time>05:00 AM PDT</time><time>06:15 AM PDT</time>
+				  </div>
+				  <div class="details">
+					<h3>
+					  Warm Up
+					</h3>
+					<div class="location">
+					</div>
+				  </div>
+				</li>
+				<li>
+				  <div class="time">
+					<time>06:15 AM PDT</time><time>07:15 AM PDT</time>
+				  </div>
+				  <div class="details">
+					<h3>
+						How to build a WebXR Game in 13KB
+					</h3>
+					<div class="social">
+						<a href="https://www.twitch.tv/sorskoot" class="speakerIcons"><i class="twitch icon"></i></a>
+						<a href="https://twitter.com/sorskoot" class="speakerIcons"><i class="twitter square icon"></i></a>
+					</div>
+					<div class="speaker">
+						Timmy Kokke (sorskoot)
+					</div>
+				  </div>
+				</li>
+				<li>
+				  <div class="time">
+					<time>07:15 AM PDT</time><time>08:15 AM PDT</time>
+				  </div>
+				  <div class="details">
+					<h3>
+						Finding your niche to stay relevant, in your career
+					</h3>
+					<div class="social">
+						<a href="https://www.twitch.tv/luckynos7evin" class="speakerIcons"><i class="twitch icon"></i></a>
+						<a href="https://twitter.com/TheS7evin" class="speakerIcons"><i class="twitter square icon"></i></a>
+					</div>
+					<div class="speaker">
+						Andy Morrell (LuckyNoS7evin)
+					</div>
+				  </div>
+				</li>
+				<li>
+				  <div class="time">
+					<time>08:15 AM PDT</time><time>09:15 AM PDT</time>
+				  </div>
+				  <div class="details">
+					<h3>
+						Using Azure IoT Central to form a basis for your IoT Solutions
+					</h3>
+					<div class="social">
+						<a href="https://www.twitch.tv/codingbandit" class="speakerIcons"><i class="twitch icon"></i></a>
+						<a href="https://twitter.com/careypayette" class="speakerIcons"><i class="twitter square icon"></i></a>
+					</div>
+					<div class="speaker">
+						Carey Payette (codingbandit)
+					</div>
+				  </div>
+				</li>
+				<li>
+				  <div class="time">
+					<time>09:15 AM PDT</time><time>10:15 AM PDT</time>
+				  </div>
+				  <div class="details">
+					<h3>
+						How to build up resilience and keep burnout at bay
+					</h3>
+					<div class="social">
+						<a href="https://www.twitch.tv/codingbandit" class="speakerIcons"><i class="twitch icon"></i></a>
+						<a href="https://twitter.com/careypayette" class="speakerIcons"><i class="twitter square icon"></i></a>
+					</div>
+					<div class="speaker">
+						Jochen Lillich (FullStackLive)
+					</div>
+				  </div>
+				</li>
+				<li>
+				  <div class="time">
+					<time>10:15 AM PDT</time><time>11:15 AM PDT</time>
+				  </div>
+				  <div class="details">
+					<h3>
+						Techniques for Interacting with Microcontrollers in the Browser
+					</h3>
+					<div class="social">
+						<a href="https://www.twitch.tv/noopkat" class="speakerIcons"><i class="twitch icon"></i></a>
+						<a href="https://twitter.com/noopkat" class="speakerIcons"><i class="twitter square icon"></i></a>
+					</div>
+					<div class="speaker">
+						Suz Hinton (noopkat)
+					</div>
+				  </div>
+				</li>
+				<li>
+				  <div class="time">
+					<time>11:15 AM PDT</time><time>12:15 PM PDT</time>
+				  </div>
+				  <div class="details">
+					<h3>
+						Debugging Python: Goodbye Print, Hello Debugger
+					</h3>
+					<div class="social">
+						<a href="https://www.twitch.tv/nnjaio" class="speakerIcons"><i class="twitch icon"></i></a>
+						<a href="https://twitter.com/nnja" class="speakerIcons"><i class="twitter square icon"></i></a>
+					</div>
+					<div class="speaker">
+						Nina Zakharenko (nnjaio)
+					</div>
+				  </div>
+				</li>
+				<li>
+				  <div class="time">
+					<time>12:15 PM PDT</time><time>1:15 PM PDT</time>
+				  </div>
+				  <div class="details">
+					<h3>
+						Reproducing AlphaZero
+					</h3>
+					<div class="social">
+						<a href="https://www.twitch.tv/nick_larsen" class="speakerIcons"><i class="twitch icon"></i></a>
+						<a href="https://twitter.com/fody" class="speakerIcons"><i class="twitter square icon"></i></a>
+					</div>
+					<div class="speaker">
+						Nick Larsen (nick_larsen)
+					</div>
+				  </div>
+				</li>
+			  </ol>
+			</div>
 		</div>
 	</section>
 

--- a/index.html
+++ b/index.html
@@ -344,7 +344,8 @@
 		<div class="sectionSeparator"></div>
 	</section>
 
-	<!-- Speakers Section -->
+	<!-- Schedule Section -->
+	<!-- From Code Pen: https://codepen.io/jeroenseverein/pen/GJOvez -->
 	<section class="section-schedule js--section-schedule" id="schedule">
 		<div class="row">
 			<h1 class="titles">Schedule</h1>

--- a/style.css
+++ b/style.css
@@ -218,7 +218,8 @@ i.twitter.icon {
 i.twitch.icon:hover,
 i.twitter.icon:hover {
 	color: black;
-	font-size: 35px;	
+	transition: all .2s ease-in-out;
+	transform: scale(1.2);
 }
 
 

--- a/style.css
+++ b/style.css
@@ -12,7 +12,7 @@ body {
 
 .row {
 	padding: 0 4%;
-	}   
+	}
 
 /* Main Navi */
 .main-nav {
@@ -27,7 +27,7 @@ body {
 .main-nav li {
 	display: inline-block;
 	/*changing to inline-block so they can be side by side*/
-	margin-left: 40px; 
+	margin-left: 40px;
 }
 
 .main-nav li a:link,
@@ -176,8 +176,8 @@ h3 {
 }
 
 /* Unordered List bullets: */
-ul.circle {
-  list-style-type: circle;
+ul.no-bullets {
+  list-style-type: none;
 }
 
 ul.ulspeakers {
@@ -261,4 +261,81 @@ i:hover {
 .sigs {
 	font-size: 1.2rem;
 	color: #555;
+}
+
+/* Schedule List Styles */
+
+.schedule-list {
+	padding: 0 2em;
+}
+
+.schedule-list h1, .schedule-list h2, .schedule-list h3 {
+font-weight: 500;
+margin: 0;
+text-align: left;
+}
+
+.schedule-list h1{
+font-weight: 700;
+margin-top: 0.3348979767em;
+margin-bottom: 0.6944444444em;
+font-size: 1.44em;
+}
+
+.schedule-list h2{
+margin-bottom: 0.4822530864em;
+font-size: 1em;
+}
+
+.schedule-list h3 {
+margin: 0 0 0.3348979767em;
+font-weight: 400;
+font-size: 1em;
+}
+
+.schedule-list ol {
+padding: 0;
+list-style: none;
+border-top: 1px solid #ccc;
+margin: 0 -0.4822530864em 1.44em;
+}
+
+.schedule-list li {
+display: flex;
+padding: 0.5em;
+background: #fff;
+border-bottom: 1px solid #ccc;
+}
+
+.schedule-list .time {
+padding: 0 0.8333333333em;
+flex: 0 0 7em;
+text-align: center;
+}
+
+.schedule-list time {
+font-size: 0.8333333333em;
+display: block;
+line-height: 1.2em;
+}
+.schedule-list time:nth-of-type(2) {
+color: #999;
+}
+
+.schedule-list .details {
+overflow: hidden;
+border-left: 2px solid;
+padding-left: 0.6944444444em;
+width: 100%;
+}
+
+.schedule-list .speaker {
+color: #999;
+font-size: 0.8333333333em;
+}
+
+.schedule-list .social {
+float: right;
+color: #999;
+font-size: 0.8333333333em;
 }

--- a/style.css
+++ b/style.css
@@ -264,6 +264,7 @@ i:hover {
 }
 
 /* Schedule List Styles */
+/* From Code Pen: https://codepen.io/jeroenseverein/pen/GJOvez */
 
 .schedule-list {
 	padding: 0 2em;


### PR DESCRIPTION
Add HTML schedule with talk times, speaker names, talk titles, and inline social links.

**Note that only Part A is added, not Part B**

### Preview
![image](https://user-images.githubusercontent.com/2030983/78730511-df7a3100-78f1-11ea-9f7a-f52093a89a8b.png)
